### PR TITLE
refactor : 신규일 게시글인 경우만 insert하고, 수정 게시글은 update 제거

### DIFF
--- a/src/main/java/com/devlogmoa/domain/blog/BlogContents.java
+++ b/src/main/java/com/devlogmoa/domain/blog/BlogContents.java
@@ -4,7 +4,14 @@ import com.devlogmoa.domain.BaseTimeEntity;
 import com.devlogmoa.web.dto.response.rss.RssResponseDto;
 import lombok.Getter;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import java.util.Date;
 
 @Getter
@@ -31,11 +38,6 @@ public class BlogContents extends BaseTimeEntity {
         }
 
         return pubDate.compareTo(publishedDate) < 0 && !this.pubLink.equals(pubLink);
-    }
-
-    public void updatePublish(RssResponseDto rssResponseDto) {
-        this.pubDate = rssResponseDto.getPubDate();
-        this.title = rssResponseDto.getTitle();
     }
 
     public static BlogContents createPublish(RssResponseDto rssResponseDto) {

--- a/src/main/java/com/devlogmoa/domain/blog/ContentsStatus.java
+++ b/src/main/java/com/devlogmoa/domain/blog/ContentsStatus.java
@@ -1,0 +1,13 @@
+package com.devlogmoa.domain.blog;
+
+/**
+ * 메일링을 위해 신규컨텐츠가 있는지 없는지 체크하기 위한 클래스
+ */
+public enum ContentsStatus {
+
+    NEW(true, "신규 컨텐츠 있음"),
+    DEFAULT(false, "신규 컨텐츠 없음, 클래스 설명용");
+
+    ContentsStatus(boolean status, String description) {
+    }
+}

--- a/src/main/java/com/devlogmoa/mail/MailService.java
+++ b/src/main/java/com/devlogmoa/mail/MailService.java
@@ -1,5 +1,6 @@
 package com.devlogmoa.mail;
 
+import com.devlogmoa.domain.blog.ContentsStatus;
 import com.devlogmoa.domain.member.Member;
 import com.devlogmoa.repository.member.MemberRepository;
 import com.devlogmoa.scheduler.RssReader;
@@ -18,7 +19,7 @@ public class MailService {
     private final MemberRepository memberRepository;
 
     public void sendEmail() {
-        if (RssReader.newRssStatus) {
+        if (ContentsStatus.NEW == RssReader.contentsStatus) {
             List<Member> findMembers = memberRepository.findAll();
             SimpleMailMessage message = new SimpleMailMessage();
 
@@ -31,6 +32,6 @@ public class MailService {
             }
         }
 
-        RssReader.newRssStatus = false;
+        RssReader.contentsStatus = ContentsStatus.DEFAULT;
     }
 }

--- a/src/main/java/com/devlogmoa/scheduler/RssReader.java
+++ b/src/main/java/com/devlogmoa/scheduler/RssReader.java
@@ -58,12 +58,12 @@ public class RssReader {
             BlogContents findLastBlogContents = blogContentsRepository.findTopByBlogIdOrderByPubDateDesc(blog.getId());
 
             for (SyndEntry entry : entries) {
-                mergeBlogContents(blog, entry, findLastBlogContents);
+                createBlogContents(blog, entry, findLastBlogContents);
             }
         }
     }
 
-    private void mergeBlogContents(Blog blog, SyndEntry entry, BlogContents findLastBlogContents) {
+    private void createBlogContents(Blog blog, SyndEntry entry, BlogContents findLastBlogContents) {
         if (findLastBlogContents == null || findLastBlogContents.isNewPublish(entry.getPublishedDate(), entry.getLink())) {
             BlogContents blogDetail = BlogContents.createPublish(RssResponseDto.newRss(entry, blog));
 
@@ -72,14 +72,6 @@ public class RssReader {
             if (!newRssStatus) {
                 newRssStatus = true;
             }
-        } else {
-            updatePublish(findLastBlogContents, entry);
-        }
-    }
-
-    private void updatePublish(BlogContents findLastBlogContents, SyndEntry entry) {
-        if (findLastBlogContents.getPubLink().equals(entry.getLink())) {
-            findLastBlogContents.updatePublish(RssResponseDto.existNewRss(entry));
         }
     }
 }

--- a/src/main/java/com/devlogmoa/scheduler/RssReader.java
+++ b/src/main/java/com/devlogmoa/scheduler/RssReader.java
@@ -2,6 +2,7 @@ package com.devlogmoa.scheduler;
 
 import com.devlogmoa.domain.blog.Blog;
 import com.devlogmoa.domain.blog.BlogContents;
+import com.devlogmoa.domain.blog.ContentsStatus;
 import com.devlogmoa.domain.blog.UsageStatus;
 import com.devlogmoa.repository.blog.BlogContentsRepository;
 import com.devlogmoa.repository.blog.BlogRepository;
@@ -26,7 +27,7 @@ public class RssReader {
     private final BlogRepository blogRepository;
     private final BlogContentsRepository blogContentsRepository;
 
-    public static boolean newRssStatus = false;
+    public static ContentsStatus contentsStatus = ContentsStatus.DEFAULT;
 
     @Transactional
     public void createRssData(String url, String rssUrl) throws IOException, FeedException {
@@ -66,12 +67,9 @@ public class RssReader {
     private void createBlogContents(Blog blog, SyndEntry entry, BlogContents findLastBlogContents) {
         if (findLastBlogContents == null || findLastBlogContents.isNewPublish(entry.getPublishedDate(), entry.getLink())) {
             BlogContents blogDetail = BlogContents.createPublish(RssResponseDto.newRss(entry, blog));
-
             blogContentsRepository.save(blogDetail);
 
-            if (!newRssStatus) {
-                newRssStatus = true;
-            }
+            contentsStatus = ContentsStatus.NEW;
         }
     }
 }

--- a/src/main/java/com/devlogmoa/web/dto/response/rss/RssResponseDto.java
+++ b/src/main/java/com/devlogmoa/web/dto/response/rss/RssResponseDto.java
@@ -29,13 +29,4 @@ public class RssResponseDto {
 
         return rssResponseDto;
     }
-
-    public static RssResponseDto existNewRss(SyndEntry entry) {
-        RssResponseDto rssResponseDto = new RssResponseDto();
-
-        rssResponseDto.pubDate = entry.getPublishedDate();
-        rssResponseDto.title = entry.getTitle();
-
-        return rssResponseDto;
-    }
 }


### PR DESCRIPTION
새로운 게시글이 올라왔을 경우에만 insert 하고(기존 기능), 수정된 게시글은 update하는 기능을 제거 시켰음.
새로운 내용을 보는 것이 핵심이고 기존 게시글에 추가된 내용은 핵심이 아니기 때문.
업무 문서 같은 경우면 update도 중요하겠지만, devlogmoa는 새로운 게시글이 있는지 확인하기 위해 사용하는 서비스이므로
이와 같은 선택을 함